### PR TITLE
fix: lava near testnet rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ NEAR_WALLET_SECRET_KEY=your-wallet-private-key
 NEAR_WALLET_PUBLIC_KEY=your-wallet-public-key
 NEAR_ADDRESS=your-account.near
 NEAR_NETWORK=testnet  # mainnet or testnet
-NEAR_RPC_URL=https://near-testnet.lava.build
+NEAR_RPC_URL=https://neart.lava.build
 NEAR_SLIPPAGE=0.01  # 1% slippage tolerance
 ```
 

--- a/src/actions/swap.ts
+++ b/src/actions/swap.ts
@@ -80,7 +80,7 @@ async function swapToken(
         const tokenOut = await ftGetTokenMetadata(outputTokenId);
         const networkId = runtime.getSetting("NEAR_NETWORK") || "testnet";
         const nodeUrl =
-            runtime.getSetting("NEAR_RPC_URL") || "https://near-testnet.lava.build";
+            runtime.getSetting("NEAR_RPC_URL") || "https://neart.lava.build";
 
         // Get all pools for estimation
         // ratedPools, unRatedPools,
@@ -296,7 +296,7 @@ export const executeSwap: Action = {
                 keyStore,
                 nodeUrl:
                     runtime.getSetting("NEAR_RPC_URL") ||
-                    "https://near-testnet.lava.build",
+                    "https://neart.lava.build",
             });
 
             // Execute swap

--- a/src/actions/transfer.ts
+++ b/src/actions/transfer.ts
@@ -64,7 +64,7 @@ async function transferNEAR(
 ): Promise<string> {
     const networkId = runtime.getSetting("NEAR_NETWORK") || "testnet";
     const nodeUrl =
-        runtime.getSetting("NEAR_RPC_URL") || "https://near-testnet.lava.build";
+        runtime.getSetting("NEAR_RPC_URL") || "https://neart.lava.build";
     const accountId = runtime.getSetting("NEAR_ADDRESS");
     const secretKey = runtime.getSetting("NEAR_WALLET_SECRET_KEY");
 

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -45,7 +45,7 @@ export function getConfig(
         case "testnet":
             return {
                 networkId: "testnet",
-                nodeUrl: "https://near-testnet.lava.build",
+                nodeUrl: "https://neart.lava.build",
                 walletUrl: "https://wallet.testnet.near.org",
                 indexerUrl: "https://testnet-indexer.ref-finance.com",
                 WRAP_NEAR_CONTRACT_ID: "wrap.testnet",

--- a/src/providers/wallet.ts
+++ b/src/providers/wallet.ts
@@ -16,7 +16,7 @@ const PROVIDER_CONFIG = {
         process.env.NEAR_RPC_URL ||
         (process.env.NEAR_NETWORK === "mainnet" 
             ? "https://near.lava.build"
-            : "https://near-testnet.lava.build"),
+            : "https://neart.lava.build"),
     walletUrl: `https://${process.env.NEAR_NETWORK || "testnet"}.mynearwallet.com/`,
     helperUrl: `https://helper.${process.env.NEAR_NETWORK || "testnet"}.near.org`,
     explorerUrl: `https://${process.env.NEAR_NETWORK || "testnet"}.nearblocks.io`,


### PR DESCRIPTION
Since the original Lava testnet RPC for NEAR (https://near-testnet.lava.build) is broken now, let's use the new one: https://neart.lava.build